### PR TITLE
Other crud endpoints

### DIFF
--- a/src/hero.rs
+++ b/src/hero.rs
@@ -7,10 +7,20 @@ use rocket_contrib::json::Json;
 use super::schema;
 use schema::hero;
 
-#[derive(AsChangeset, Serialize, Deserialize, Debug, Queryable, Insertable)]
+// gotta have 2 structs, one for input, one for persistence: https://github.com/diesel-rs/diesel/issues/1440#issuecomment-354573185
+#[derive(AsChangeset, Serialize, Deserialize, Debug, Queryable)]
+#[table_name = "hero"]
+pub struct HeroWithId {
+    pub id: i32,
+    pub name: String,
+    pub identity: String,
+    pub hometown: String,
+    pub age: i32,
+}
+
+#[derive(AsChangeset, Serialize, Deserialize, Debug, Insertable)]
 #[table_name = "hero"]
 pub struct Hero {
-    pub id: Option<i32>,
     pub name: String,
     pub identity: String,
     pub hometown: String,
@@ -18,19 +28,44 @@ pub struct Hero {
 }
 
 impl Hero {
-    pub fn create(connection: &diesel::MysqlConnection, h: &Hero) -> Hero {
+    pub fn create(connection: &diesel::MysqlConnection, h: &Hero) -> HeroWithId {
         diesel::insert_into(hero::table)
             .values(h)
             .execute(connection)
             .expect("Error creating new hero");
 
         // TODO return record we just inserted instead of mock
-        Hero {
-            id: Some(1),
+        HeroWithId {
+            id: 1,
             name: String::from("Superman"),
             identity: String::from("Clark Kent"),
             hometown: String::from("Metropolis"),
             age: 32,
-        }
+        };
+
+        hero::table
+            .order(hero::id.desc())
+            .first(connection)
+            .unwrap()
+    }
+
+    pub fn read(connection: &MysqlConnection) -> Vec<HeroWithId> {
+        hero::table
+            .order(hero::id)
+            .load::<HeroWithId>(connection)
+            .unwrap()
+    }
+
+    pub fn update(connection: &MysqlConnection, id: i32, h: HeroWithId) -> bool {
+        diesel::update(hero::table.find(id))
+            .set(&h)
+            .execute(connection)
+            .is_ok()
+    }
+
+    pub fn delete(connection: &MysqlConnection, id: i32) -> bool {
+        diesel::delete(hero::table.find(id))
+            .execute(connection)
+            .is_ok()
     }
 }

--- a/src/hero.rs
+++ b/src/hero.rs
@@ -34,15 +34,6 @@ impl Hero {
             .execute(connection)
             .expect("Error creating new hero");
 
-        // TODO return record we just inserted instead of mock
-        HeroWithId {
-            id: 1,
-            name: String::from("Superman"),
-            identity: String::from("Clark Kent"),
-            hometown: String::from("Metropolis"),
-            age: 32,
-        };
-
         hero::table
             .order(hero::id.desc())
             .first(connection)

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,14 +16,14 @@ use rocket::Rocket;
 extern crate diesel;
 //use rocket_contrib::databases::diesel;
 
-use rocket_contrib::json::Json;
+use rocket_contrib::json::{Json, JsonValue};
 
 #[database("my_db")]
 struct MyDatabase(diesel::MysqlConnection);
 
 mod hero;
 mod schema;
-use hero::Hero;
+use hero::{Hero, HeroWithId};
 
 #[cfg(test)]
 mod tests;
@@ -34,17 +34,40 @@ fn hello() -> &'static str {
 }
 
 #[post("/", data = "<hero>")]
-fn create(conn: MyDatabase, hero: Json<Hero>) -> Json<Hero> {
+fn create(conn: MyDatabase, hero: Json<Hero>) -> Json<HeroWithId> {
     let insert = Hero {
-        id: None,
         ..hero.into_inner()
     };
     Json(Hero::create(&conn.0, &insert))
 }
 
+#[get("/")]
+fn read(conn: MyDatabase) -> Json<JsonValue> {
+    Json(json!(Hero::read(&conn.0)))
+}
+
+#[put("/<id>", data = "<hero>")]
+fn update(conn: MyDatabase, id: i32, hero: Json<HeroWithId>) -> Json<JsonValue> {
+    // TODO should they be updating *with* ID?
+    let update = HeroWithId {
+        ..hero.into_inner()
+    };
+    Json(json!({
+        "success": Hero::update(&conn.0, id, update)
+    }))
+}
+
+#[delete("/<id>")]
+fn delete(conn: MyDatabase, id: i32) -> Json<JsonValue> {
+    Json(json!({
+        "success": Hero::delete(&conn.0, id)
+    }))
+}
+
 fn rocket() -> Rocket {
     rocket::ignite()
-        .mount("/hero", routes![create])
+        .mount("/hero", routes![create, update, delete])
+        .mount("/heroes", routes![read])
         .mount("/", routes![hello])
         .attach(MyDatabase::fairing())
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,4 +1,4 @@
-use super::hero::Hero;
+use super::hero::HeroWithId;
 use super::rocket;
 use rocket::http::Status;
 use rocket::local::Client;
@@ -13,8 +13,8 @@ fn test_hello() {
 
 #[test]
 fn it_works() {
-    let hero = Hero {
-        id: Some(1),
+    let hero = HeroWithId {
+        id: 1,
         name: String::from("Superman"),
         identity: String::from("Clark Kent"),
         hometown: String::from("Metropolis"),
@@ -27,10 +27,10 @@ fn it_works() {
         r#"{"id":1,"name":"Superman","identity":"Clark Kent","hometown":"Metropolis","age":32}"#
     );
 
-    let deserialized: Hero = serde_json::from_str(&serialized).unwrap();
+    let deserialized: HeroWithId = serde_json::from_str(&serialized).unwrap();
     println!("deserialized = {:?}", deserialized);
 
-    assert_eq!(deserialized.id, Some(1));
+    assert_eq!(deserialized.id, 1);
     assert_eq!(deserialized.name, "Superman");
     assert_eq!(deserialized.identity, "Clark Kent");
     assert_eq!(deserialized.hometown, "Metropolis");


### PR DESCRIPTION
Added endpoints for PUT, DELETE, and bulk GET. Still need "detail view", e.g., `GET /hero/1`.

Also had to add another struct, so we have one for inserting, one for querying. See https://github.com/diesel-rs/diesel/issues/1440#issuecomment-354573185.

Diesel didn't like the optional i32.