### PR TITLE
Implement PATCH request

### DIFF
--- a/src/hero.rs
+++ b/src/hero.rs
@@ -103,10 +103,10 @@ impl Hero {
         let mut new = HeroWithId { ..extant };
         for field in h.fields {
             match field.as_ref() {
-                "name" => new.name = h.name,
-                "identity" => new.identity = h.identity,
-                "age" => new.age = h.age,
-                "hometown" => new.hometown = h.hometown,
+                "name" => new.name = h.name.clone(),
+                "identity" => new.identity = h.identity.clone(),
+                "age" => new.age = h.age.clone(),
+                "hometown" => new.hometown = h.hometown.clone(),
                 x => (),
             }
         }

--- a/src/hero.rs
+++ b/src/hero.rs
@@ -31,6 +31,16 @@ pub struct Hero {
     pub image_url: Option<String>,
 }
 
+#[derive(Serialize, Deserialize, Debug)]
+pub struct HeroPatch {
+    pub fields: Vec<String>,
+    pub name: String,
+    pub identity: String,
+    pub hometown: String,
+    pub age: i32,
+    pub image_url: Option<String>,
+}
+
 fn get_status_code_from_diesel_err(e: DieselError) -> i32 {
     if e == DieselError::NotFound {
         404
@@ -79,11 +89,48 @@ impl Hero {
         Hero::find_by_id(connection, id).map_or_else(|e| diesel_err_to_json(e), |h| Json(json!(h)))
     }
 
-    pub fn update(connection: &MysqlConnection, id: i32, h: HeroWithId) -> bool {
+    pub fn update(connection: &MysqlConnection, id: i32, h: HeroWithId) -> Json<JsonValue> {
         diesel::update(hero::table.find(id))
             .set(&h)
             .execute(connection)
-            .is_ok()
+            .map_or_else(
+                |e| diesel_err_to_json(e),
+                |extant| Hero::get_detail(connection, id)
+            )
+    }
+
+    fn patch_hero_fields(h: HeroPatch, extant: HeroWithId) -> Option<HeroWithId> {
+        let mut new = HeroWithId {
+            ..extant
+        };
+        for field in h.fields {
+            match field.as_ref() {
+                "name" => new.name = h.name,
+                "identity" => new.identity = h.identity,
+                "age" => new.age = h.age,
+                "hometown" => new.hometown = h.hometown,
+                x => (),
+            }
+        }
+        let mm = new;
+        Some(mm)
+    }
+
+    fn do_patch(connection: &MysqlConnection, id: i32, h: HeroPatch, extant: HeroWithId) -> Json<JsonValue> {
+        Hero::patch_hero_fields(h, extant).map_or_else(
+            || Json(json!({
+        "error": "bad patch",
+        "status_code": "400",
+    })),
+            |new| Hero::update(connection, id, new)
+        )
+    }
+
+    pub fn patch(connection: &MysqlConnection, id: i32, h: HeroPatch) -> Json<JsonValue> {
+        Hero::find_by_id(connection, id).map_or_else(
+            |e| diesel_err_to_json(e),
+            |extant| Hero::do_patch(connection, id, h, extant)
+        )
     }
 
     pub fn delete(connection: &MysqlConnection, id: i32) -> bool {

--- a/src/hero.rs
+++ b/src/hero.rs
@@ -95,14 +95,12 @@ impl Hero {
             .execute(connection)
             .map_or_else(
                 |e| diesel_err_to_json(e),
-                |extant| Hero::get_detail(connection, id)
+                |extant| Hero::get_detail(connection, id),
             )
     }
 
     fn patch_hero_fields(h: HeroPatch, extant: HeroWithId) -> Option<HeroWithId> {
-        let mut new = HeroWithId {
-            ..extant
-        };
+        let mut new = HeroWithId { ..extant };
         for field in h.fields {
             match field.as_ref() {
                 "name" => new.name = h.name,
@@ -116,20 +114,27 @@ impl Hero {
         Some(mm)
     }
 
-    fn do_patch(connection: &MysqlConnection, id: i32, h: HeroPatch, extant: HeroWithId) -> Json<JsonValue> {
+    fn do_patch(
+        connection: &MysqlConnection,
+        id: i32,
+        h: HeroPatch,
+        extant: HeroWithId,
+    ) -> Json<JsonValue> {
         Hero::patch_hero_fields(h, extant).map_or_else(
-            || Json(json!({
-        "error": "bad patch",
-        "status_code": "400",
-    })),
-            |new| Hero::update(connection, id, new)
+            || {
+                Json(json!({
+                    "error": "bad patch",
+                    "status_code": "400",
+                }))
+            },
+            |new| Hero::update(connection, id, new),
         )
     }
 
     pub fn patch(connection: &MysqlConnection, id: i32, h: HeroPatch) -> Json<JsonValue> {
         Hero::find_by_id(connection, id).map_or_else(
             |e| diesel_err_to_json(e),
-            |extant| Hero::do_patch(connection, id, h, extant)
+            |extant| Hero::do_patch(connection, id, h, extant),
         )
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,7 +28,7 @@ struct MyDatabase(diesel::MysqlConnection);
 
 mod hero;
 mod schema;
-use hero::{Hero, HeroWithId, HeroPatch};
+use hero::{Hero, HeroPatch, HeroWithId};
 
 #[cfg(test)]
 mod tests;

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,7 +28,7 @@ struct MyDatabase(diesel::MysqlConnection);
 
 mod hero;
 mod schema;
-use hero::{Hero, HeroWithId};
+use hero::{Hero, HeroWithId, HeroPatch};
 
 #[cfg(test)]
 mod tests;
@@ -62,9 +62,15 @@ fn update(conn: MyDatabase, id: i32, hero: Json<HeroWithId>) -> Json<JsonValue> 
     let update = HeroWithId {
         ..hero.into_inner()
     };
-    Json(json!({
-        "success": Hero::update(&conn.0, id, update)
-    }))
+    Hero::update(&conn.0, id, update)
+}
+
+#[patch("/<id>", data = "<hero>")]
+fn patch(conn: MyDatabase, id: i32, hero: Json<HeroPatch>) -> Json<JsonValue> {
+    let update = HeroPatch {
+        ..hero.into_inner()
+    };
+    Hero::patch(&conn.0, id, update)
 }
 
 #[delete("/<id>")]
@@ -98,7 +104,7 @@ fn rocket() -> Rocket {
     rocket::ignite()
         .mount(
             "/hero",
-            routes![create, update, delete, get_bulk, get_detail],
+            routes![create, update, delete, get_bulk, get_detail, patch],
         )
         .mount("/", routes![hello])
         .attach(MyDatabase::fairing())

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -36,5 +36,8 @@ fn it_works() {
     assert_eq!(deserialized.identity, "Clark Kent");
     assert_eq!(deserialized.hometown, "Metropolis");
     assert_eq!(deserialized.age, 32);
-    assert_eq!(deserialized.image_url, Some(String::from("https://images.com/superman")));
+    assert_eq!(
+        deserialized.image_url,
+        Some(String::from("https://images.com/superman"))
+    );
 }


### PR DESCRIPTION
```
http PATCH http://localhost:8000/hero/13 fields:='["identity"]' identity="Barry Henry Allen"
```

## Things learned
- string doesn't implement Copy because it points to heap memory and a copy would be unsafe, thus it must be cloned. https://users.rust-lang.org/t/cant-derive-copy-because-of-string/18665